### PR TITLE
Converting PosixPath to str before reading the point cloud

### DIFF
--- a/apps/test_scan.py
+++ b/apps/test_scan.py
@@ -19,7 +19,7 @@ def read_point_cloud(filename):
     if ext == ".bin":
         scan = np.fromfile(filename, dtype=np.float32).reshape((-1, 4))[:, :3]
     else:
-        scan = o3d.io.read_point_cloud(filename).points
+        scan = o3d.io.read_point_cloud(str(filename)).points
     return np.asarray(scan, dtype=np.float64)
 
 


### PR DESCRIPTION
In the current implementation, I get an error if the file extension is not `.bin`:
```shell
TypeError: read_point_cloud(): incompatible function arguments. The following argument types are supported:
    1. (filename: str, format: str = 'auto', remove_nan_points: bool = False, remove_infinite_points: bool = False, print_progress: bool = False) -> open3d.cpu.pybind.geometry.PointCloud

Invoked with: PosixPath('/workspace/dataset/pc_uv_labelled_01.xyz')
```
This PR fixes the problem by converting PosixPath to string.